### PR TITLE
#12 Add warning for compiling examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A [signal and slots library](https://en.wikipedia.org/wiki/Signals_and_slots) implemented for the Nim programming language. The signals and slots are type checked and implemented purely in Nim.
 
 > Signals and slots is a language construct introduced in Qt for communication between objects which makes it easy to implement the observer pattern while avoiding boilerplate code. The concept is that GUI widgets, and other objects, can send signals containing event information which can be received by other objects using special member functions known as slots. This is similar to C/C++ function pointers, but the signal/slot system ensures the type-correctness of callback arguments.
-> - Wikipedia
+>
+> -   Wikipedia
 
 Note that this implementation shares many or most of the limitations you'd see in Qt's implementation. Sigils currently only has rudimentary multi-threading, but I hope to expand them over time.
 
@@ -16,6 +17,10 @@ You need to wrap procs with a `slot` to setup the proc to support recieving sign
 Connecting signals and slots is accomplished using `connect`. Note that `connect` is idempotent, meaning that you can call it on the same objects the multiple times without ill effect.
 
 ## Examples
+
+> [!WARNING]  
+> If you face issues compiling the example below (i.e. under nim 2.0.8), try compiling with the flags `--passc:"-fpermissive" --passl:"-fpermissive"`.
+> This deals with gcc's and clang's type checked pointers, which only newer nim versions (2.2.0 and above) solve for you.
 
 ```nim
 import sigils
@@ -80,7 +85,7 @@ test "signal / slot types":
 
 ## Threads
 
-Sigils 0.9+ can now do threaded signals! 
+Sigils 0.9+ can now do threaded signals!
 
 ```nim
 test "agent connect then moveToThread and run":
@@ -124,14 +129,13 @@ test "callback creation":
     clsAgent =
       connectTo(a, valueChanged) do (val: int):
         b.value = val
-  
+
   emit a.valueChanged(42)
   check b.value == 42 # callback modifies base
                       # beware capturing values like this
                       # it causes headaches, but can be handy
   check clsAgent.typeof() is ClosureAgent[(int,)]
 ```
-
 
 ## Advanced
 


### PR DESCRIPTION
"Older" Nim versions such as 2.0.8 do not deal with gcc's and clang's typed pointers.
That is a feature that these compilers only incorporated last year or so, which causes a lot of nim generated C code to on longer compile.

Therefore a warning is required to inform users of that.

closes #12